### PR TITLE
Fixed 'implicit declaration of undefined template' error.

### DIFF
--- a/src/applications/helper/bitcoin-topology-helper.h
+++ b/src/applications/helper/bitcoin-topology-helper.h
@@ -31,6 +31,7 @@
 #include "ipv4-address-helper-custom.h"
 #include "ns3/bitcoin.h"
 #include <random>
+#include <array>
 
 namespace ns3 {
 

--- a/src/applications/model/bitcoin-miner.h
+++ b/src/applications/model/bitcoin-miner.h
@@ -3,6 +3,7 @@
 
 #include "bitcoin-node.h"
 #include <random>
+#include <array>
 
 namespace ns3 {
 


### PR DESCRIPTION
When trying to compile the simulator on macOS, I encountered a large number of 'implicit declaration of undefined template' errors, like:
```
../../src/applications/helper/bitcoin-topology-helper.cc:59:27: error: implicit instantiation of undefined template 'std::__1::array<double, 1001>'
  std::array<double,1001> downloadBandwitdhIntervals {
                          ^
```

This PR fixes this issue by including the `array` header. 

FYI: I'm running the simulator with ns-3.27, and it seems to work fine in general.